### PR TITLE
fix: Register async executor as a bean using @Bean

### DIFF
--- a/core/core-api/src/main/java/io/dodn/springboot/core/api/config/AsyncConfig.java
+++ b/core/core-api/src/main/java/io/dodn/springboot/core/api/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package io.dodn.springboot.core.api.config;
 
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -12,6 +13,7 @@ import java.util.concurrent.Executor;
 @EnableAsync
 public class AsyncConfig implements AsyncConfigurer {
 
+    @Bean
     @Override
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
@@ -20,7 +22,6 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setQueueCapacity(10000);
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(10);
-        executor.initialize();
         return executor;
     }
 


### PR DESCRIPTION
## fix: Graceful Shutdown 버그 수정 위한 AsyncExecutor Bean 등록

안녕하세요! 해당 템플릿 기반으로 프로젝트를 진행하다가 비동기 동작에서 Graceful Shutdown이 제대로 동작하지 않는 문제를 발견하여, 버그를 수정하여 PR 요청 드립니다.

### 최초 발견

Spring Batch App을 구성하고 배치 수행 결과를 Slack으로 발송하는 로직을 비동기로 구현하였는데, 배치가 종료된 이후 Slack 메시지가 발송되지 않고 App이 종료되는 문제를 확인하였습니다.

### 검증

이 문제를 제대로 확인하기 위해 아래와 같은 테스트를 진행하였습니다.
해당 테스트는 프로젝트의 PR의 수정 사항에 추가하지는 않고, 따로 진행하였습니다.
(필요하시다면 해당 테스트 코드는 [테스트 커밋 링크](https://github.com/psh10066/spring-boot-java-template/commit/702025dc2441824e86ef629f1bd4277a31c60db2)에서 직접 확인하실 수 있습니다.)

1. 임시 비동기 3초 로직 수행 메서드 추가
    ```java
    @Service
    public class AsyncService {
    
        private final Logger logger = LoggerFactory.getLogger(AsyncService.class);
        final AtomicBoolean isTaskCompleted = new AtomicBoolean(false);
    
        public AtomicBoolean getIsTaskCompleted() {
            return isTaskCompleted;
        }
    
        @Async
        public void longRunningTask() throws InterruptedException {
            logger.info("비동기 작업을 시작합니다.");
    
            Thread.sleep(3000);
            isTaskCompleted.set(true);
    
            logger.info("비동기 작업이 성공적으로 완료되었습니다.");
        }
    }
    ```
2. 아래 테스트 코드 구성 후 실패 확인
    ```java
    class AsyncServiceTest {
    
        @Test
        void gracefulShutdown() throws InterruptedException {
            var context = new SpringApplicationBuilder(
                AsyncConfig.class,
                AsyncService.class
            )
                .web(WebApplicationType.NONE)
                .run();
            var asyncService = context.getBean(AsyncService.class);
    
            asyncService.longRunningTask();
            Thread.sleep(500);
            context.close();
    
            assertThat(asyncService.getIsTaskCompleted().get()).isTrue();
        }
    }
    ```
    ![image](https://github.com/user-attachments/assets/b6057e12-8987-4886-92e2-8ff6ada47ccd)

### 수정

기존 ThreadPoolTaskExecutor가 Bean으로 등록되어 있지 않아 스프링 컨텍스트 종료 시 Graceful Shutdown이 제대로 동작하지 않은 것으로 보고, ThreadPoolTaskExecutor를 Bean으로 관리하도록 설정하였습니다.
또한 Bean으로 등록됨에 따라 initialize가 불필요해지게 되어 해당 부분 삭제하였습니다.
(이에 대한 내용은 `@EnableAsync`의 주석에서도 확인할 수 있었습니다.)
![image](https://github.com/user-attachments/assets/2b3423d1-0856-4831-8058-0238da144b00)


### 검증

동일한 테스트 코드 실행 결과 성공하는 것을 확인하였습니다.
![image](https://github.com/user-attachments/assets/48a23f93-24a7-487b-b05f-6437e7a5ef37)

### 참고 사항

잘못된 내용이나 보완해야 할 내용이 있다면 편하게 말씀 부탁드립니다.
감사합니다.